### PR TITLE
feat: Use agent card as single source of truth for agent configuration

### DIFF
--- a/demo/iframe.html
+++ b/demo/iframe.html
@@ -502,8 +502,8 @@
           <span class="header-subtitle">iframe Integration</span>
         </div>
         <nav class="nav-tabs">
-          <a href="/index.html" class="nav-tab">Chat Demo</a>
-          <a href="/iframe.html" class="nav-tab active">iframe Integration</a>
+          <a href="./index.html" class="nav-tab">Chat Demo</a>
+          <a href="./iframe.html" class="nav-tab active">iframe Integration</a>
         </nav>
       </div>
       <a href="https://github.com/microsoft/a2achat" class="github-link" target="_blank">
@@ -524,15 +524,53 @@
 
         <form>
           <div class="form-group">
-            <label class="form-label" for="agent-url">A2A Agent URL</label>
-            <input 
-              type="url" 
-              id="agent-url" 
-              class="input" 
-              placeholder="https://your-a2a-agent.azurewebsites.net"
-              value=""
-            />
-            <p class="form-help">Enter the URL of your A2A-compliant agent service</p>
+            <label class="form-label">Agent Card Configuration</label>
+            <div style="display: flex; flex-direction: column; gap: 12px;">
+              <label style="display: flex; align-items: center; gap: 8px; font-weight: normal; cursor: pointer;">
+                <input type="radio" name="agent-card-mode" value="custom-url" checked />
+                <span>Provide custom URL</span>
+              </label>
+              <label style="display: flex; align-items: center; gap: 8px; font-weight: normal; cursor: pointer;">
+                <input type="radio" name="agent-card-mode" value="hardcoded" />
+                <span>Hardcode JSON (no fetch)</span>
+              </label>
+            </div>
+            
+            <div id="agent-card-url-group" style="margin-top: 12px;">
+              <input 
+                type="url" 
+                id="agent-card-url" 
+                class="input" 
+                placeholder="https://your-server.com/agent.json"
+                value=""
+                style="margin-top: 8px;"
+              />
+              <p class="form-help">Enter the custom agent card URL</p>
+            </div>
+            
+            <div id="agent-card-json-group" style="margin-top: 12px; display: none;">
+              <textarea 
+                id="agent-card-json" 
+                class="input" 
+                placeholder='{"name": "My Agent", "url": "https://agent.example.com/rpc", ...}'
+                rows="8"
+                style="margin-top: 8px; font-family: 'Cascadia Code', 'Consolas', monospace; font-size: 12px;"
+              >{
+  "name": "Test Agent",
+  "version": "1.0.0",
+  "description": "A test agent with hardcoded configuration",
+  "url": "https://agent.example.com/rpc",
+  "capabilities": {
+    "streaming": true,
+    "pushNotifications": false,
+    "stateTransitionHistory": true
+  },
+  "defaultInputModes": ["text"],
+  "defaultOutputModes": ["text"],
+  "skills": []
+}</textarea>
+              <p class="form-help">Enter the complete agent card JSON</p>
+            </div>
           </div>
 
           <div class="form-group">
@@ -718,26 +756,111 @@
       });
     });
 
-    generateBtn.addEventListener('click', () => {
-      const agentUrl = document.getElementById('agent-url').value.trim();
-      const theme = selectedTheme;
+    // Agent card mode handling
+    const agentCardModeRadios = document.getElementsByName('agent-card-mode');
+    const agentCardUrlGroup = document.getElementById('agent-card-url-group');
+    const agentCardJsonGroup = document.getElementById('agent-card-json-group');
 
-      if (!agentUrl) {
-        alert('Please enter an A2A Agent URL');
-        return;
+    agentCardModeRadios.forEach(radio => {
+      radio.addEventListener('change', () => {
+        if (agentCardUrlGroup && agentCardJsonGroup) {
+          agentCardUrlGroup.style.display = 'none';
+          agentCardJsonGroup.style.display = 'none';
+          
+          if (radio.value === 'custom-url') {
+            agentCardUrlGroup.style.display = 'block';
+          } else if (radio.value === 'hardcoded') {
+            agentCardJsonGroup.style.display = 'block';
+          }
+        }
+      });
+    });
+
+    generateBtn.addEventListener('click', async () => {
+      const selectedMode = Array.from(agentCardModeRadios).find(r => r.checked)?.value;
+      const theme = selectedTheme;
+      let agentUrl = '';
+      let agentCardData = null;
+
+      if (selectedMode === 'hardcoded') {
+        // For hardcoded JSON, extract the agent URL from the JSON
+        const agentCardJson = document.getElementById('agent-card-json').value.trim();
+        if (!agentCardJson) {
+          alert('Please enter the agent card JSON');
+          return;
+        }
+        
+        try {
+          agentCardData = JSON.parse(agentCardJson);
+          if (!agentCardData.url) {
+            alert('Agent card JSON must contain a "url" field');
+            return;
+          }
+          // Extract the base URL from the agent card URL
+          const url = new URL(agentCardData.url);
+          agentUrl = url.origin;
+        } catch (e) {
+          alert('Invalid JSON in agent card configuration: ' + e.message);
+          return;
+        }
+      } else if (selectedMode === 'custom-url') {
+        // For custom URL mode, fetch the agent card from the provided URL
+        const agentCardUrl = document.getElementById('agent-card-url').value.trim();
+        if (!agentCardUrl) {
+          alert('Please enter the custom agent card URL');
+          return;
+        }
+        
+        try {
+          const response = await fetch(agentCardUrl);
+          if (!response.ok) {
+            throw new Error(`Failed to fetch agent card: ${response.statusText}`);
+          }
+          agentCardData = await response.json();
+          if (!agentCardData.url) {
+            alert('Agent card must contain a "url" field');
+            return;
+          }
+          // Extract the base URL from the agent card URL
+          const url = new URL(agentCardData.url);
+          agentUrl = url.origin;
+        } catch (e) {
+          alert('Failed to fetch or parse agent card: ' + e.message);
+          return;
+        }
       }
 
-      // Build iframe URL
+      // Build iframe URL - only pass theme initially
       const params = new URLSearchParams({
-        agent: agentUrl,
         theme: theme
       });
+      
+      if (selectedMode === 'custom-url') {
+        const agentCardUrl = document.getElementById('agent-card-url').value.trim();
+        if (agentCardUrl) {
+          params.append('agentCard', agentCardUrl);
+        }
+      } else if (selectedMode === 'hardcoded') {
+        // For hardcoded JSON, we'll use postMessage
+        params.append('expectPostMessage', 'true');
+      }
+      
+      console.log('Building iframe with params:', {
+        selectedMode: selectedMode,
+        theme: theme,
+        paramsString: params.toString()
+      });
 
-      // Use the main demo page as the iframe source
+      // Use the index.html page as the iframe source for the embedded demo
       const currentUrl = new URL(window.location.href);
-      const iframeUrl = new URL('/', currentUrl.origin);
+      // Use relative path to the main demo page
+      const iframePath = './index.html';
+      
+      const iframeUrl = new URL(iframePath, window.location.href);
       iframeUrl.search = params.toString() + '&embedded=true';
       iframe.src = iframeUrl.toString();
+      console.log('Generated iframe URL:', iframe.src);
+      console.log('Iframe element:', iframe);
       iframe.style.display = 'block';
       placeholder.style.display = 'none';
 
@@ -745,25 +868,121 @@
       status.classList.add('connected');
       status.innerHTML = '<span class="status-dot"></span><span>Connected</span>';
 
+      // If we have hardcoded agent card data, send it via postMessage
+      if (agentCardData) {
+        // Wait for iframe to be ready
+        const handleIframeReady = (event) => {
+          if (event.data && event.data.type === 'IFRAME_READY') {
+            console.log('Iframe ready, sending agent card data');
+            iframe.contentWindow.postMessage({
+              type: 'SET_AGENT_CARD',
+              agentCard: agentCardData
+            }, '*');
+            window.removeEventListener('message', handleIframeReady);
+          }
+        };
+        
+        window.addEventListener('message', handleIframeReady);
+        
+        // Also try sending immediately in case iframe is already loaded
+        setTimeout(() => {
+          if (iframe.contentWindow) {
+            iframe.contentWindow.postMessage({
+              type: 'SET_AGENT_CARD',
+              agentCard: agentCardData
+            }, '*');
+          }
+        }, 1000);
+      }
+
       // Update code examples
-      updateCodeExamples(agentUrl, theme);
+      const agentCardUrl = selectedMode === 'custom-url' ? 
+        document.getElementById('agent-card-url').value.trim() : '';
+      updateCodeExamples(agentUrl, theme, agentCardUrl, selectedMode === 'hardcoded' ? agentCardData : null);
     });
 
-    function updateCodeExamples(agentUrl, theme) {
+    function updateCodeExamples(agentUrl, theme, agentCardUrl, agentCardData) {
       const params = new URLSearchParams({ agent: agentUrl, theme: theme });
+      if (agentCardUrl) {
+        params.append('agentCard', agentCardUrl);
+      }
+      
+      const isHardcoded = !!agentCardData;
+      if (isHardcoded) {
+        params.append('expectPostMessage', 'true');
+      }
+      
       const iframeSrc = `https://your-app.azurewebsites.net/chat?${params.toString()}&embedded=true`;
 
       // Update HTML code
-      document.getElementById('html-code').innerHTML = `<span class="comment">&lt;!-- Add this where you want the chat to appear --&gt;</span>
+      if (isHardcoded) {
+        document.getElementById('html-code').innerHTML = `<span class="comment">&lt;!-- Add this where you want the chat to appear --&gt;</span>
+<span class="tag">&lt;iframe</span>
+  <span class="attr">id</span>=<span class="string">"a2a-chat"</span>
+  <span class="attr">src</span>=<span class="string">"${iframeSrc}"</span>
+  <span class="attr">style</span>=<span class="string">"width: 100%; height: 100%; border: none;"</span>
+  <span class="attr">title</span>=<span class="string">"A2A Chat Widget"</span>
+<span class="tag">&gt;&lt;/iframe&gt;</span>
+
+<span class="tag">&lt;script&gt;</span>
+<span class="comment">// Wait for iframe to load and send agent card data</span>
+<span class="keyword">const</span> iframe = document.getElementById(<span class="string">'a2a-chat'</span>);
+<span class="keyword">const</span> agentCard = ${JSON.stringify(agentCardData, null, 2)};
+
+<span class="comment">// Listen for iframe ready signal</span>
+window.addEventListener(<span class="string">'message'</span>, <span class="keyword">function</span>(event) {
+  <span class="keyword">if</span> (event.data && event.data.type === <span class="string">'IFRAME_READY'</span>) {
+    iframe.contentWindow.postMessage({
+      type: <span class="string">'SET_AGENT_CARD'</span>,
+      agentCard: agentCard
+    }, <span class="string">'*'</span>);
+  }
+});
+<span class="tag">&lt;/script&gt;</span>`;
+      } else {
+        document.getElementById('html-code').innerHTML = `<span class="comment">&lt;!-- Add this where you want the chat to appear --&gt;</span>
 <span class="tag">&lt;iframe</span>
   <span class="attr">id</span>=<span class="string">"a2a-chat"</span>
   <span class="attr">src</span>=<span class="string">"${iframeSrc}"</span>
   <span class="attr">style</span>=<span class="string">"width: 100%; height: 100%; border: none;"</span>
   <span class="attr">title</span>=<span class="string">"A2A Chat Widget"</span>
 <span class="tag">&gt;&lt;/iframe&gt;</span>`;
+      }
 
       // Update React code
-      document.getElementById('react-code').innerHTML = `<span class="keyword">import</span> React <span class="keyword">from</span> <span class="string">'react'</span>;
+      if (isHardcoded) {
+        document.getElementById('react-code').innerHTML = `<span class="keyword">import</span> React, { useEffect, useRef } <span class="keyword">from</span> <span class="string">'react'</span>;
+
+<span class="keyword">function</span> ChatWidget() {
+  <span class="keyword">const</span> iframeRef = useRef(null);
+  <span class="keyword">const</span> iframeSrc = <span class="string">"${iframeSrc}"</span>;
+  <span class="keyword">const</span> agentCard = ${JSON.stringify(agentCardData, null, 2)};
+  
+  useEffect(() => {
+    <span class="keyword">const</span> handleMessage = (event) => {
+      <span class="keyword">if</span> (event.data && event.data.type === <span class="string">'IFRAME_READY'</span>) {
+        iframeRef.current?.contentWindow?.postMessage({
+          type: <span class="string">'SET_AGENT_CARD'</span>,
+          agentCard: agentCard
+        }, <span class="string">'*'</span>);
+      }
+    };
+    
+    window.addEventListener(<span class="string">'message'</span>, handleMessage);
+    <span class="keyword">return</span> () => window.removeEventListener(<span class="string">'message'</span>, handleMessage);
+  }, []);
+  
+  <span class="keyword">return</span> (
+    <span class="tag">&lt;iframe</span>
+      <span class="attr">ref</span>={iframeRef}
+      <span class="attr">src</span>={iframeSrc}
+      <span class="attr">style</span>={{ width: <span class="string">'100%'</span>, height: <span class="string">'100%'</span>, border: <span class="string">'none'</span> }}
+      <span class="attr">title</span>=<span class="string">"A2A Chat Widget"</span>
+    <span class="tag">/&gt;</span>
+  );
+}`;
+      } else {
+        document.getElementById('react-code').innerHTML = `<span class="keyword">import</span> React <span class="keyword">from</span> <span class="string">'react'</span>;
 
 <span class="keyword">function</span> ChatWidget() {
   <span class="keyword">const</span> iframeSrc = <span class="string">"${iframeSrc}"</span>;
@@ -776,17 +995,55 @@
     <span class="tag">/&gt;</span>
   );
 }`;
+      }
 
       // Update Vue code
-      document.getElementById('vue-code').innerHTML = `<span class="tag">&lt;template&gt;</span>
+      if (isHardcoded) {
+        document.getElementById('vue-code').innerHTML = `<span class="tag">&lt;template&gt;</span>
+  <span class="tag">&lt;iframe</span>
+    <span class="attr">ref</span>=<span class="string">"chatIframe"</span>
+    <span class="attr">src</span>=<span class="string">"${iframeSrc}"</span>
+    <span class="attr">style</span>=<span class="string">"width: 100%; height: 100%; border: none;"</span>
+    <span class="attr">title</span>=<span class="string">"A2A Chat Widget"</span>
+  <span class="tag">&gt;&lt;/iframe&gt;</span>
+<span class="tag">&lt;/template&gt;</span>
+
+<span class="tag">&lt;script&gt;</span>
+<span class="keyword">export default</span> {
+  data() {
+    <span class="keyword">return</span> {
+      agentCard: ${JSON.stringify(agentCardData, null, 2)}
+    };
+  },
+  mounted() {
+    window.addEventListener(<span class="string">'message'</span>, this.handleMessage);
+  },
+  beforeDestroy() {
+    window.removeEventListener(<span class="string">'message'</span>, this.handleMessage);
+  },
+  methods: {
+    handleMessage(event) {
+      <span class="keyword">if</span> (event.data && event.data.type === <span class="string">'IFRAME_READY'</span>) {
+        this.$refs.chatIframe.contentWindow.postMessage({
+          type: <span class="string">'SET_AGENT_CARD'</span>,
+          agentCard: this.agentCard
+        }, <span class="string">'*'</span>);
+      }
+    }
+  }
+}
+<span class="tag">&lt;/script&gt;</span>`;
+      } else {
+        document.getElementById('vue-code').innerHTML = `<span class="tag">&lt;template&gt;</span>
   <span class="tag">&lt;iframe</span>
     <span class="attr">src</span>=<span class="string">"${iframeSrc}"</span>
     <span class="attr">style</span>=<span class="string">"width: 100%; height: 100%; border: none;"</span>
     <span class="attr">title</span>=<span class="string">"A2A Chat Widget"</span>
   <span class="tag">&gt;&lt;/iframe&gt;</span>
 <span class="tag">&lt;/template&gt;</span>`;
+      }
 
-      // Update Blazor code
+      // Update Blazor code - for simplicity, Blazor will always use URL params
       document.getElementById('blazor-code').innerHTML = `<span class="comment">@* ChatWidget.razor *@</span>
 <span class="tag">&lt;iframe</span>
   <span class="attr">src</span>=<span class="string">"@IframeSrc"</span>
@@ -797,8 +1054,9 @@
 <span class="keyword">@code</span> {
     <span class="keyword">private string</span> AgentUrl = <span class="string">"${agentUrl}"</span>;
     <span class="keyword">private string</span> Theme = <span class="string">"${theme}"</span>;
+    ${agentCardUrl ? `<span class="keyword">private string</span> AgentCardUrl = <span class="string">"${agentCardUrl}"</span>;` : ''}
     
-    <span class="keyword">private string</span> IframeSrc => <span class="string">$"https://your-app.azurewebsites.net/chat?agent={Uri.EscapeDataString(AgentUrl)}&theme={Theme}&embedded=true"</span>;
+    <span class="keyword">private string</span> IframeSrc => <span class="string">$"https://your-app.azurewebsites.net/chat?agent={Uri.EscapeDataString(AgentUrl)}&theme={Theme}${agentCardUrl ? '&agentCard={Uri.EscapeDataString(AgentCardUrl)}' : ''}&embedded=true"</span>;
 }`;
     }
 
@@ -822,8 +1080,8 @@
     const urlParams = new URLSearchParams(window.location.search);
     const agentParam = urlParams.get('agent');
     if (agentParam) {
-      document.getElementById('agent-url').value = agentParam;
-      generateBtn.click();
+      // Note: Agent parameter is no longer used since we removed well-known mode
+      // Users must provide either a custom URL or hardcoded JSON
     }
   </script>
 </body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -479,8 +479,8 @@
           <span class="header-subtitle">Interactive Demo</span>
         </div>
         <nav class="nav-tabs">
-          <a href="/index.html" class="nav-tab active">Chat Demo</a>
-          <a href="/iframe.html" class="nav-tab">iframe Integration</a>
+          <a href="./index.html" class="nav-tab active">Chat Demo</a>
+          <a href="./iframe.html" class="nav-tab">iframe Integration</a>
         </nav>
       </div>
       <a href="https://github.com/microsoft/a2achat" class="github-link" target="_blank">
@@ -501,17 +501,54 @@
         
         <form>
           <div class="form-group">
-            <label class="form-label" for="agent-url">A2A Agent URL</label>
-            <input 
-              type="url" 
-              id="agent-url" 
-              class="input" 
-              placeholder="https://your-a2a-agent.azurewebsites.net"
-              value=""
-            />
-            <p class="form-help">Enter the URL of your A2A-compliant agent endpoint</p>
+            <label class="form-label">Agent Card Configuration</label>
+            <div style="display: flex; flex-direction: column; gap: 12px;">
+              <label style="display: flex; align-items: center; gap: 8px; font-weight: normal; cursor: pointer;">
+                <input type="radio" name="agent-card-mode" value="custom-url" checked />
+                <span>Provide custom URL</span>
+              </label>
+              <label style="display: flex; align-items: center; gap: 8px; font-weight: normal; cursor: pointer;">
+                <input type="radio" name="agent-card-mode" value="hardcoded" />
+                <span>Hardcode JSON (no fetch)</span>
+              </label>
+            </div>
+            
+            <div id="agent-card-url-group" style="margin-top: 12px;">
+              <input 
+                type="url" 
+                id="agent-card-url" 
+                class="input" 
+                placeholder="https://your-server.com/agent.json"
+                value=""
+                style="margin-top: 8px;"
+              />
+              <p class="form-help">Enter the custom agent card URL</p>
+            </div>
+            
+            <div id="agent-card-json-group" style="margin-top: 12px; display: none;">
+              <textarea 
+                id="agent-card-json" 
+                class="input" 
+                placeholder='{"name": "My Agent", "url": "https://agent.example.com/rpc", ...}'
+                rows="8"
+                style="margin-top: 8px; font-family: 'Cascadia Code', 'Consolas', monospace; font-size: 12px;"
+              >{
+  "name": "Test Agent",
+  "version": "1.0.0",
+  "description": "A test agent with hardcoded configuration",
+  "url": "https://agent.example.com/rpc",
+  "capabilities": {
+    "streaming": true,
+    "pushNotifications": false,
+    "stateTransitionHistory": true
+  },
+  "defaultInputModes": ["text"],
+  "defaultOutputModes": ["text"],
+  "skills": []
+}</textarea>
+              <p class="form-help">Enter the complete agent card JSON</p>
+            </div>
           </div>
-
 
           <div class="form-group">
             <label class="form-label">Theme</label>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=/demo/">
+    <title>Redirecting to Demo...</title>
+</head>
+<body>
+    <p>Redirecting to <a href="/demo/">demo</a>...</p>
+    <script>
+        // Fallback JavaScript redirect
+        window.location.href = '/demo/';
+    </script>
+</body>
+</html>

--- a/src/components/ChatWindow/ChatWindow.test.tsx
+++ b/src/components/ChatWindow/ChatWindow.test.tsx
@@ -43,7 +43,7 @@ vi.mock('../../hooks/useChatConnection', () => ({
 describe('ChatWindow', () => {
   const mockSendMessage = vi.fn();
   const defaultProps = {
-    agentUrl: 'https://agent.example.com',
+    agentCard: 'https://agent.example.com/agent.json',
     theme: {},
     placeholder: 'Type here...',
     welcomeMessage: 'Welcome!'
@@ -137,13 +137,13 @@ describe('ChatWindow', () => {
     expect(input).toBeDisabled();
   });
 
-  it('should use A2A connection with provided agentUrl', async () => {
+  it('should use A2A connection with provided agentCard', async () => {
     const { useChatConnection } = vi.mocked(await import('../../hooks/useChatConnection'));
     
     render(<ChatWindow {...defaultProps} />);
     
     expect(useChatConnection).toHaveBeenCalledWith({
-      agentUrl: 'https://agent.example.com',
+      agentCard: 'https://agent.example.com/agent.json',
       onMessage: undefined,
       onConnectionChange: undefined
     });
@@ -164,7 +164,7 @@ describe('ChatWindow', () => {
 
   it('should handle all props correctly', () => {
     const props = {
-      agentUrl: 'https://agent.example.com',
+      agentCard: 'https://agent.example.com/agent.json',
       theme: {
         branding: {
           logoPosition: 'header' as const
@@ -202,7 +202,7 @@ describe('ChatWindow', () => {
     render(<ChatWindow {...props} />);
     
     expect(useChatConnection).toHaveBeenCalledWith({
-      agentUrl: 'https://agent.example.com',
+      agentCard: 'https://agent.example.com/agent.json',
       onMessage,
       onConnectionChange
     });

--- a/src/components/ChatWindow/ChatWindow.tsx
+++ b/src/components/ChatWindow/ChatWindow.tsx
@@ -6,13 +6,13 @@ import { useChatConnection } from '../../hooks/useChatConnection';
 import styles from './ChatWindow.module.css';
 import type { ChatWidgetProps } from '../../types';
 
-export interface ChatWindowProps extends Omit<ChatWidgetProps, 'agentUrl'> {
-  agentUrl: string; // Required A2A agent URL
+export interface ChatWindowProps extends ChatWidgetProps {
+  // All props come from ChatWidgetProps, which now uses agentCard
 }
 
 export function ChatWindow(props: ChatWindowProps) {
   const {
-    agentUrl,
+    agentCard,
     theme,
     placeholder,
     welcomeMessage,
@@ -25,7 +25,7 @@ export function ChatWindow(props: ChatWindowProps) {
 
   const chatTheme = useTheme(theme);
   const { isConnected, agentName, sendMessage } = useChatConnection({
-    agentUrl,
+    agentCard,
     onMessage,
     onConnectionChange
   });

--- a/src/hooks/useA2AClient.ts
+++ b/src/hooks/useA2AClient.ts
@@ -1,11 +1,11 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { A2AClient, type A2AStreamEventData } from '../a2aclient/A2AClient';
-import type { Message as A2AMessage, Part } from '../a2aclient/types';
+import type { Message as A2AMessage, Part, AgentCard } from '../a2aclient/types';
 import type { Message } from '../types';
 import { createMessage, formatPart, createArtifactMessage, createGroupedArtifactMessage, type ArtifactData } from '../utils/messageUtils';
 
 interface UseA2AClientProps {
-  agentUrl?: string;
+  agentCard?: string | AgentCard;
   onConnectionChange?: (connected: boolean) => void;
   onMessage?: (message: Message) => void;
   onTypingChange?: (isTyping: boolean) => void;
@@ -21,7 +21,7 @@ interface A2AClientState {
 }
 
 export function useA2AClient({
-  agentUrl,
+  agentCard,
   onConnectionChange,
   onMessage,
   onTypingChange,
@@ -36,13 +36,15 @@ export function useA2AClient({
   });
 
   useEffect(() => {
-    if (!agentUrl) {
+    if (!agentCard) {
       clientRef.current = null;
       setState(prev => ({ ...prev, isConnected: false }));
       return;
     }
 
-    const client = new A2AClient(agentUrl, { debug: true });
+    const client = new A2AClient(agentCard, { 
+      debug: true
+    });
     clientRef.current = client;
 
     // Initialize connection
@@ -68,7 +70,7 @@ export function useA2AClient({
     return () => {
       clientRef.current = null;
     };
-  }, [agentUrl, onConnectionChange]);
+  }, [agentCard, onConnectionChange]);
 
   const handleStreamEvent = useCallback((
     event: A2AStreamEventData,

--- a/src/hooks/useChatConnection.test.ts
+++ b/src/hooks/useChatConnection.test.ts
@@ -66,16 +66,16 @@ describe('useChatConnection', () => {
   });
 
   it('initializes with A2A client connection', () => {
-    const agentUrl = 'http://test.agent';
+    const agentCard = 'http://test.agent/agent.json';
     const onMessage = vi.fn();
     const onConnectionChange = vi.fn();
     
     const { result } = renderHook(() => 
-      useChatConnection({ agentUrl, onMessage, onConnectionChange })
+      useChatConnection({ agentCard, onMessage, onConnectionChange })
     );
     
     expect(mockUseA2AClient).toHaveBeenCalledWith({
-      agentUrl,
+      agentCard,
       onConnectionChange: expect.any(Function),
       onMessage: expect.any(Function),
       onTypingChange: expect.any(Function),
@@ -90,7 +90,7 @@ describe('useChatConnection', () => {
     const onMessage = vi.fn();
     
     renderHook(() => 
-      useChatConnection({ agentUrl: 'http://test.agent', onMessage })
+      useChatConnection({ agentCard: 'http://test.agent/agent.json', onMessage })
     );
     
     // Get the message handler passed to useA2AClient
@@ -117,7 +117,7 @@ describe('useChatConnection', () => {
     const onConnectionChange = vi.fn();
     
     renderHook(() => 
-      useChatConnection({ agentUrl: 'http://test.agent', onConnectionChange })
+      useChatConnection({ agentCard: 'http://test.agent/agent.json', onConnectionChange })
     );
     
     // Get the connection handler passed to useA2AClient
@@ -141,7 +141,7 @@ describe('useChatConnection', () => {
 
   it('handles typing changes', () => {
     renderHook(() => 
-      useChatConnection({ agentUrl: 'http://test.agent' })
+      useChatConnection({ agentCard: 'http://test.agent/agent.json' })
     );
     
     // Get the typing handler passed to useA2AClient
@@ -174,7 +174,7 @@ describe('useChatConnection', () => {
     mockA2AClient.sendMessage.mockResolvedValue(undefined);
     
     const { result } = renderHook(() => 
-      useChatConnection({ agentUrl: 'http://test.agent' })
+      useChatConnection({ agentCard: 'http://test.agent/agent.json' })
     );
     
     await act(async () => {
@@ -211,7 +211,7 @@ describe('useChatConnection', () => {
     mockA2AClient.sendMessage.mockResolvedValue(undefined);
     
     const { result } = renderHook(() => 
-      useChatConnection({ agentUrl: 'http://test.agent' })
+      useChatConnection({ agentCard: 'http://test.agent/agent.json' })
     );
     
     await act(async () => {
@@ -240,7 +240,7 @@ describe('useChatConnection', () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     
     const { result } = renderHook(() => 
-      useChatConnection({ agentUrl: 'http://test.agent' })
+      useChatConnection({ agentCard: 'http://test.agent/agent.json' })
     );
     
     await act(async () => {
@@ -272,7 +272,7 @@ describe('useChatConnection', () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     
     const { result } = renderHook(() => 
-      useChatConnection({ agentUrl: 'http://test.agent' })
+      useChatConnection({ agentCard: 'http://test.agent/agent.json' })
     );
     
     await act(async () => {
@@ -291,7 +291,7 @@ describe('useChatConnection', () => {
     mockA2AClient.sendMessage.mockResolvedValue(undefined);
     
     const { result } = renderHook(() => 
-      useChatConnection({ agentUrl: 'http://test.agent' })
+      useChatConnection({ agentCard: 'http://test.agent/agent.json' })
     );
     
     // Send first message
@@ -329,7 +329,7 @@ describe('useChatConnection', () => {
 
   it('maintains stable callback references', () => {
     const { result, rerender } = renderHook(() => 
-      useChatConnection({ agentUrl: 'http://test.agent' })
+      useChatConnection({ agentCard: 'http://test.agent/agent.json' })
     );
     
     const firstSendMessage = result.current.sendMessage;
@@ -343,7 +343,7 @@ describe('useChatConnection', () => {
 
   it('updates when A2A client state changes', () => {
     const { result, rerender } = renderHook(() => 
-      useChatConnection({ agentUrl: 'http://test.agent' })
+      useChatConnection({ agentCard: 'http://test.agent/agent.json' })
     );
     
     expect(result.current.isConnected).toBe(true);
@@ -387,7 +387,7 @@ describe('useChatConnection', () => {
     mockA2AClient.sendMessage.mockResolvedValue(undefined);
     
     const { result } = renderHook(() => 
-      useChatConnection({ agentUrl: 'http://test.agent' })
+      useChatConnection({ agentCard: 'http://test.agent/agent.json' })
     );
     
     await act(async () => {

--- a/src/hooks/useChatConnection.ts
+++ b/src/hooks/useChatConnection.ts
@@ -2,16 +2,17 @@ import { useCallback } from 'react';
 import { useA2AClient } from './useA2AClient';
 import { useChatStore } from '../store/chatStore';
 import type { Message, Attachment } from '../types';
+import type { AgentCard } from '../a2aclient/types';
 import { createMessage } from '../utils/messageUtils';
 
 interface UseChatConnectionProps {
-  agentUrl: string;
+  agentCard: string | AgentCard;
   onMessage?: (message: Message) => void;
   onConnectionChange?: (connected: boolean) => void;
 }
 
 export function useChatConnection({
-  agentUrl,
+  agentCard,
   onMessage,
   onConnectionChange
 }: UseChatConnectionProps) {
@@ -36,7 +37,7 @@ export function useChatConnection({
 
   // Initialize A2A connection
   const a2aClient = useA2AClient({
-    agentUrl,
+    agentCard,
     onConnectionChange: handleConnectionChange,
     onMessage: handleMessage,
     onTypingChange: handleTypingChange,

--- a/src/lib/iframe.test.tsx
+++ b/src/lib/iframe.test.tsx
@@ -86,7 +86,7 @@ describe('iframe', () => {
   });
 
   it('initializes with agent URL from data attribute', async () => {
-    document.documentElement.dataset.agentUrl = 'http://test.agent';
+    document.documentElement.dataset.agentCard = 'http://test.agent/agent.json';
     
     await import('./iframe');
     
@@ -94,27 +94,27 @@ describe('iframe', () => {
     expect(mockRoot.render).toHaveBeenCalled();
     
     const renderCall = mockRoot.render.mock.calls[0][0];
-    expect(renderCall.props.agentUrl).toBe('http://test.agent');
+    expect(renderCall.props.agentCard).toBe('http://test.agent/agent.json');
     expect(renderCall.props.allowFileUpload).toBe(true);
   });
 
   it('initializes with agent URL from URL parameter', async () => {
-    window.location.search = '?agentUrl=http://url.agent';
+    window.location.search = '?agentCard=http://url.agent/agent.json';
     
     await import('./iframe');
     
     const renderCall = mockRoot.render.mock.calls[0][0];
-    expect(renderCall.props.agentUrl).toBe('http://url.agent');
+    expect(renderCall.props.agentCard).toBe('http://url.agent/agent.json');
   });
 
   it('prefers data attribute over URL parameter for agent URL', async () => {
-    document.documentElement.dataset.agentUrl = 'http://data.agent';
-    window.location.search = '?agentUrl=http://url.agent';
+    document.documentElement.dataset.agentCard = 'http://data.agent/agent.json';
+    window.location.search = '?agentCard=http://url.agent/agent.json';
     
     await import('./iframe');
     
     const renderCall = mockRoot.render.mock.calls[0][0];
-    expect(renderCall.props.agentUrl).toBe('http://data.agent');
+    expect(renderCall.props.agentCard).toBe('http://data.agent/agent.json');
   });
 
   it('throws error when agent URL is missing', async () => {
@@ -125,11 +125,11 @@ describe('iframe', () => {
       expect.any(Error)
     );
     expect(document.body.innerHTML).toContain('Failed to load chat widget');
-    expect(document.body.innerHTML).toContain('data-agent-url is required');
+    expect(document.body.innerHTML).toContain('data-agent-card is required');
   });
 
   it('parses theme from data attributes', async () => {
-    document.documentElement.dataset.agentUrl = 'http://test.agent';
+    document.documentElement.dataset.agentCard = 'http://test.agent/agent.json';
     document.documentElement.dataset.themePrimary = '#ff0000';
     document.documentElement.dataset.themeBackground = '#000000';
     
@@ -152,7 +152,7 @@ describe('iframe', () => {
   });
 
   it('parses branding from data attributes', async () => {
-    document.documentElement.dataset.agentUrl = 'http://test.agent';
+    document.documentElement.dataset.agentCard = 'http://test.agent/agent.json';
     document.documentElement.dataset.logoUrl = 'http://logo.png';
     document.documentElement.dataset.logoSize = 'large';
     document.documentElement.dataset.logoPosition = 'footer';
@@ -170,7 +170,7 @@ describe('iframe', () => {
   });
 
   it('parses other configuration from data attributes', async () => {
-    document.documentElement.dataset.agentUrl = 'http://test.agent';
+    document.documentElement.dataset.agentCard = 'http://test.agent/agent.json';
     document.documentElement.dataset.userId = 'user123';
     document.documentElement.dataset.placeholder = 'Type here...';
     document.documentElement.dataset.welcomeMessage = 'Welcome!';
@@ -190,18 +190,18 @@ describe('iframe', () => {
   });
 
   it('parses configuration from URL parameters', async () => {
-    window.location.search = '?agentUrl=http://test.agent&userId=user456&placeholder=Ask me';
+    window.location.search = '?agentCard=http://test.agent/agent.json&userId=user456&placeholder=Ask me';
     
     await import('./iframe');
     
     const renderCall = mockRoot.render.mock.calls[0][0];
-    expect(renderCall.props.agentUrl).toBe('http://test.agent');
+    expect(renderCall.props.agentCard).toBe('http://test.agent/agent.json');
     expect(renderCall.props.userId).toBe('user456');
     expect(renderCall.props.placeholder).toBe('Ask me');
   });
 
   it('parses valid metadata JSON', async () => {
-    document.documentElement.dataset.agentUrl = 'http://test.agent';
+    document.documentElement.dataset.agentCard = 'http://test.agent/agent.json';
     document.documentElement.dataset.metadata = '{"key": "value", "num": 123}';
     
     await import('./iframe');
@@ -211,7 +211,7 @@ describe('iframe', () => {
   });
 
   it('handles invalid metadata JSON gracefully', async () => {
-    document.documentElement.dataset.agentUrl = 'http://test.agent';
+    document.documentElement.dataset.agentCard = 'http://test.agent/agent.json';
     document.documentElement.dataset.metadata = 'invalid json';
     
     await import('./iframe');
@@ -226,7 +226,7 @@ describe('iframe', () => {
   });
 
   it('handles missing chat-root element', async () => {
-    document.documentElement.dataset.agentUrl = 'http://test.agent';
+    document.documentElement.dataset.agentCard = 'http://test.agent/agent.json';
     document.body.innerHTML = ''; // Remove chat-root
     
     await import('./iframe');
@@ -246,7 +246,7 @@ describe('iframe', () => {
       configurable: true,
     });
     
-    document.documentElement.dataset.agentUrl = 'http://test.agent';
+    document.documentElement.dataset.agentCard = 'http://test.agent/agent.json';
     
     const addEventListenerSpy = vi.spyOn(document, 'addEventListener');
     
@@ -270,7 +270,7 @@ describe('iframe', () => {
       configurable: true,
     });
     
-    document.documentElement.dataset.agentUrl = 'http://test.agent';
+    document.documentElement.dataset.agentCard = 'http://test.agent/agent.json';
     
     await import('./iframe');
     
@@ -279,7 +279,7 @@ describe('iframe', () => {
   });
 
   it('does not include theme when no theme attributes are set', async () => {
-    document.documentElement.dataset.agentUrl = 'http://test.agent';
+    document.documentElement.dataset.agentCard = 'http://test.agent/agent.json';
     
     await import('./iframe');
     
@@ -288,7 +288,7 @@ describe('iframe', () => {
   });
 
   it('uses default branding values when not specified', async () => {
-    document.documentElement.dataset.agentUrl = 'http://test.agent';
+    document.documentElement.dataset.agentCard = 'http://test.agent/agent.json';
     document.documentElement.dataset.logoUrl = 'http://logo.png';
     // logoSize and logoPosition not specified
     
@@ -305,7 +305,7 @@ describe('iframe', () => {
   });
 
   it('handles allowFileUpload as true by default', async () => {
-    document.documentElement.dataset.agentUrl = 'http://test.agent';
+    document.documentElement.dataset.agentCard = 'http://test.agent/agent.json';
     
     await import('./iframe');
     
@@ -314,7 +314,7 @@ describe('iframe', () => {
   });
 
   it('handles empty allowedFileTypes string', async () => {
-    document.documentElement.dataset.agentUrl = 'http://test.agent';
+    document.documentElement.dataset.agentCard = 'http://test.agent/agent.json';
     document.documentElement.dataset.allowedFileTypes = '';
     
     await import('./iframe');
@@ -324,7 +324,7 @@ describe('iframe', () => {
   });
 
   it('trims whitespace from allowed file types', async () => {
-    document.documentElement.dataset.agentUrl = 'http://test.agent';
+    document.documentElement.dataset.agentCard = 'http://test.agent/agent.json';
     document.documentElement.dataset.allowedFileTypes = ' .pdf , .doc , .txt ';
     
     await import('./iframe');
@@ -339,7 +339,7 @@ describe('iframe', () => {
       throw errorObject;
     });
     
-    document.documentElement.dataset.agentUrl = 'http://test.agent';
+    document.documentElement.dataset.agentCard = 'http://test.agent/agent.json';
     
     await import('./iframe');
     
@@ -351,7 +351,7 @@ describe('iframe', () => {
       throw 'String error';
     });
     
-    document.documentElement.dataset.agentUrl = 'http://test.agent';
+    document.documentElement.dataset.agentCard = 'http://test.agent/agent.json';
     
     await import('./iframe');
     

--- a/src/lib/iframe.tsx
+++ b/src/lib/iframe.tsx
@@ -1,4 +1,5 @@
 import { createRoot } from 'react-dom/client';
+import { useState, useEffect } from 'react';
 import { ChatWindow } from '../components/ChatWindow';
 import type { ChatWidgetProps, ChatTheme } from '../types';
 import '../styles/base.css';
@@ -7,15 +8,115 @@ import '../styles/base.css';
 function parseConfig(): ChatWidgetProps {
   const params = new URLSearchParams(window.location.search);
   const dataset = document.documentElement.dataset;
-
-  // Get agent URL (required)
-  const agentUrl = dataset.agentUrl || params.get('agentUrl');
-  if (!agentUrl) {
-    throw new Error('data-agent-url is required');
+  // Get agent card URL (required) - support both 'agent' and 'agentCard' parameters
+  const agentCard = dataset.agentCard || params.get('agentCard') || params.get('agent');
+  
+  if (!agentCard) {
+    throw new Error('data-agent-card is required');
   }
 
-  // Parse theme from data attributes
+  // Parse theme from data attributes or URL parameter
   const theme: Partial<ChatTheme> = {};
+  
+  // Check if theme is provided as URL parameter (for demo)
+  const themeParam = params.get('theme');
+  if (themeParam) {
+    // Handle predefined theme names from demo
+    const themeColors: Record<string, Partial<ChatTheme['colors']>> = {
+      default: {
+        primary: '#667eea',
+        primaryText: '#ffffff',
+        background: '#ffffff',
+        surface: '#f8fafc',
+        text: '#1e293b',
+        textSecondary: '#64748b',
+        border: '#e2e8f0',
+        error: '#ef4444',
+        success: '#10b981'
+      },
+      blue: {
+        primary: '#2563eb',
+        primaryText: '#ffffff',
+        background: '#ffffff',
+        surface: '#f0f9ff',
+        text: '#0c4a6e',
+        textSecondary: '#0369a1',
+        border: '#bfdbfe',
+        error: '#dc2626',
+        success: '#059669'
+      },
+      green: {
+        primary: '#10b981',
+        primaryText: '#ffffff',
+        background: '#ffffff',
+        surface: '#f0fdf4',
+        text: '#14532d',
+        textSecondary: '#166534',
+        border: '#bbf7d0',
+        error: '#dc2626',
+        success: '#059669'
+      },
+      red: {
+        primary: '#ef4444',
+        primaryText: '#ffffff',
+        background: '#ffffff',
+        surface: '#fef2f2',
+        text: '#450a0a',
+        textSecondary: '#991b1b',
+        border: '#fecaca',
+        error: '#b91c1c',
+        success: '#16a34a'
+      },
+      purple: {
+        primary: '#8b5cf6',
+        primaryText: '#ffffff',
+        background: '#ffffff',
+        surface: '#faf5ff',
+        text: '#3b0764',
+        textSecondary: '#6b21a8',
+        border: '#e9d5ff',
+        error: '#dc2626',
+        success: '#16a34a'
+      },
+      teal: {
+        primary: '#14b8a6',
+        primaryText: '#ffffff',
+        background: '#ffffff',
+        surface: '#f0fdfa',
+        text: '#134e4a',
+        textSecondary: '#0f766e',
+        border: '#99f6e4',
+        error: '#dc2626',
+        success: '#059669'
+      },
+      orange: {
+        primary: '#f97316',
+        primaryText: '#ffffff',
+        background: '#ffffff',
+        surface: '#fff7ed',
+        text: '#431407',
+        textSecondary: '#c2410c',
+        border: '#fed7aa',
+        error: '#dc2626',
+        success: '#16a34a'
+      },
+      pink: {
+        primary: '#ec4899',
+        primaryText: '#ffffff',
+        background: '#ffffff',
+        surface: '#fdf2f8',
+        text: '#500724',
+        textSecondary: '#9f1239',
+        border: '#fbcfe8',
+        error: '#be123c',
+        success: '#16a34a'
+      }
+    };
+    
+    if (themeColors[themeParam]) {
+      theme.colors = themeColors[themeParam] as ChatTheme['colors'];
+    }
+  }
 
   // Colors
   if (dataset.themePrimary || dataset.themeBackground) {
@@ -44,9 +145,10 @@ function parseConfig(): ChatWidgetProps {
     };
   }
 
+
   // Other props
   const props: ChatWidgetProps = {
-    agentUrl,
+    agentCard,
     theme: Object.keys(theme).length > 0 ? theme : undefined,
     userId: dataset.userId || params.get('userId') || undefined,
     placeholder: dataset.placeholder || params.get('placeholder') || undefined,
@@ -69,10 +171,81 @@ function parseConfig(): ChatWidgetProps {
   return props;
 }
 
+// Wrapper component that can receive agent card via postMessage
+function IframeWrapper(props: ChatWidgetProps) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [agentCard, setAgentCard] = useState<any>(null);
+  const [isWaitingForAgentCard, setIsWaitingForAgentCard] = useState(false);
+  
+  // Check if we should wait for postMessage
+  const params = new URLSearchParams(window.location.search);
+  const expectPostMessage = params.get('expectPostMessage') === 'true';
+  
+  useEffect(() => {
+    if (expectPostMessage) {
+      setIsWaitingForAgentCard(true);
+      
+      // Listen for postMessage
+      const handleMessage = (event: MessageEvent) => {
+        
+        // Validate message
+        if (event.data && event.data.type === 'SET_AGENT_CARD') {
+          setAgentCard(event.data.agentCard);
+          setIsWaitingForAgentCard(false);
+          
+          // Send acknowledgment
+          if (event.source && typeof event.source.postMessage === 'function') {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            event.source.postMessage({ type: 'AGENT_CARD_RECEIVED' }, event.origin as any);
+          }
+        }
+      };
+      
+      window.addEventListener('message', handleMessage);
+      
+      // Send ready signal to parent
+      if (window.parent !== window) {
+        window.parent.postMessage({ type: 'IFRAME_READY' }, '*');
+      }
+      
+      return () => {
+        window.removeEventListener('message', handleMessage);
+      };
+    }
+  }, [expectPostMessage]);
+  
+  // Show loading state while waiting for agent card
+  if (expectPostMessage && isWaitingForAgentCard) {
+    return (
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100vh',
+        fontFamily: 'sans-serif',
+        color: '#666',
+        textAlign: 'center',
+        padding: '20px'
+      }}>
+        <div>
+          <h3 style={{ color: '#333', marginBottom: '10px' }}>Waiting for Configuration</h3>
+          <p style={{ margin: 0 }}>Waiting for agent card data via postMessage...</p>
+        </div>
+      </div>
+    );
+  }
+  
+  // If we received an agent card via postMessage, use that instead
+  const finalProps = agentCard ? { ...props, agentCard } : props;
+  return <ChatWindow {...finalProps} />;
+}
+
 // Initialize the widget
 function init() {
+  
   try {
     const config = parseConfig();
+    
     const container = document.getElementById('chat-root');
 
     if (!container) {
@@ -80,9 +253,17 @@ function init() {
     }
 
     const root = createRoot(container);
-    root.render(<ChatWindow {...config} />);
+    
+    root.render(<IframeWrapper {...config} />);
   } catch (error) {
     console.error('Failed to initialize chat widget:', error);
+    console.error('Error details:', {
+      message: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+      location: window.location.href,
+      search: window.location.search
+    });
+    
     document.body.innerHTML = `
       <div style="
         display: flex;
@@ -97,6 +278,8 @@ function init() {
         <div>
           <h3 style="color: #333; margin-bottom: 10px;">Failed to load chat widget</h3>
           <p style="margin: 0;">${typeof error === 'object' && error && 'message' in error && typeof (error as { message?: unknown }).message === 'string' ? (error as { message: string }).message : String(error)}</p>
+          <p style="margin-top: 10px; font-size: 12px; color: #999;">URL: ${window.location.href}</p>
+          <p style="margin-top: 5px; font-size: 12px; color: #999;">Parameters: ${window.location.search || 'none'}</p>
         </div>
       </div>
     `;

--- a/src/lib/index.test.tsx
+++ b/src/lib/index.test.tsx
@@ -53,7 +53,7 @@ describe('lib/index', () => {
 
   describe('mountChatWidget', () => {
     const defaultProps: ChatWidgetProps = {
-      agentUrl: 'http://test.agent',
+      agentCard: 'http://test.agent/agent.json',
     };
 
     it('mounts widget with HTMLElement container', () => {
@@ -119,7 +119,7 @@ describe('lib/index', () => {
       document.body.appendChild(container);
       
       const props: ChatWidgetProps = {
-        agentUrl: 'http://test.agent',
+        agentCard: 'http://test.agent/agent.json',
         placeholder: 'Type here...',
         welcomeMessage: 'Welcome!',
         allowFileUpload: false,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { AgentCard } from '../a2aclient/types';
+
 export interface Message {
   id: string;
   content: string;
@@ -54,7 +56,7 @@ export interface ChatTheme {
 }
 
 export interface ChatWidgetProps {
-  agentUrl: string;
+  agentCard: string | AgentCard;
   theme?: Partial<ChatTheme>;
   onMessage?: (message: Message) => void;
   onConnectionChange?: (connected: boolean) => void;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,11 +52,11 @@ export default defineConfig(({ mode }) => {
           }
         },
         outDir: 'dist/iframe',
-        sourcemap: false,
+        sourcemap: true,
         minify: 'terser',
         terserOptions: {
           compress: {
-            drop_console: true,
+            drop_console: false, // Keep console logs for debugging
             drop_debugger: true
           }
         }
@@ -99,11 +99,11 @@ export default defineConfig(({ mode }) => {
           }
         },
         outDir: 'dist/demo',
-        sourcemap: false,
+        sourcemap: true,
         minify: 'terser',
         terserOptions: {
           compress: {
-            drop_console: true,
+            drop_console: false, // Keep console logs for debugging
             drop_debugger: true
           }
         }


### PR DESCRIPTION
## Summary

This PR refactors the A2A Chat widget to use the agent card as the single source of truth for agent configuration, eliminating the need for separate agent URL parameters and simplifying the API.

## Motivation

Previously, the widget required users to provide both an agent URL and optionally an agent card URL, which created confusion about which was the source of truth. The agent card already contains the agent's service endpoint URL, making the separate agent URL parameter redundant.

## Changes

### 🏗️ Architecture Changes
- **Removed** `agentUrl` parameter from all components and interfaces
- **Replaced** with `agentCard: string | AgentCard` parameter that accepts either:
  - A URL string pointing to the agent card JSON file
  - An AgentCard object directly
- **Removed** support for well-known URL patterns (/.well-known/agent.json)
- **Simplified** A2AClient constructor to only accept agent card

### 📦 Component Updates
- `ChatWindow`: Now accepts `agentCard` prop instead of `agentUrl`
- `useA2AClient`: Updated to pass agent card to A2AClient
- `useChatConnection`: Simplified to use agent card parameter
- `A2AClient`: Refactored to fetch or use agent card as the configuration source

### 🎨 Demo Updates
- Removed "Use default .well-known URL" option
- Simplified to two configuration modes:
  1. **Provide custom URL**: Direct URL to agent card JSON
  2. **Hardcode JSON**: Paste agent card JSON directly
- Updated iframe integration to support both modes

### 🧪 Test Updates
- Updated all test files to use `agentCard` parameter
- Fixed mock data to include complete AgentCard objects
- All 296 tests passing ✅

## Breaking Changes

⚠️ **This is a breaking change for consumers of the library**

### Before
```tsx
<ChatWindow 
  agentUrl="https://my-agent.com"
  agentCardUrl="https://my-agent.com/custom/agent.json"
/>
```

### After
```tsx
// Option 1: Provide agent card URL
<ChatWindow 
  agentCard="https://my-agent.com/agent.json"
/>

// Option 2: Provide agent card object
<ChatWindow 
  agentCard={{
    name: "My Agent",
    url: "https://my-agent.com/rpc",
    // ... other agent card fields
  }}
/>
```

## Benefits

✅ **Simpler API**: One parameter instead of multiple URL parameters  
✅ **Clearer mental model**: Agent card is the configuration source  
✅ **More flexible**: Can provide URL or object directly  
✅ **Reduced confusion**: No ambiguity about which URL to use  
✅ **Better security**: Option to embed agent card without network fetch  

## Testing

- Run `npm test` - All tests passing
- Run `npm run type-check` - No TypeScript errors
- Run `npm run dev` - Demo works with both configuration modes
- Tested iframe integration with custom URL and hardcoded JSON modes

## Screenshots

https://github.com/user-attachments/assets/8c670ef4-77c9-44ec-994f-d9c8132e281b


